### PR TITLE
Re-build language server

### DIFF
--- a/language-server/package-lock.json
+++ b/language-server/package-lock.json
@@ -246,22 +246,22 @@
       "dev": true
     },
     "es-abstract": {
-      "version": "1.17.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
-      "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+      "version": "1.17.6",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+      "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
-        "is-callable": "^1.1.5",
-        "is-regex": "^1.0.5",
+        "is-callable": "^1.2.0",
+        "is-regex": "^1.1.0",
         "object-inspect": "^1.7.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.0",
-        "string.prototype.trimleft": "^2.1.1",
-        "string.prototype.trimright": "^2.1.1"
+        "string.prototype.trimend": "^1.0.1",
+        "string.prototype.trimstart": "^1.0.1"
       }
     },
     "es-to-primitive": {
@@ -821,28 +821,6 @@
         "es-abstract": "^1.17.5"
       }
     },
-    "string.prototype.trimleft": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
-      "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5",
-        "string.prototype.trimstart": "^1.0.0"
-      }
-    },
-    "string.prototype.trimright": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
-      "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5",
-        "string.prototype.trimend": "^1.0.0"
-      }
-    },
     "string.prototype.trimstart": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
@@ -889,8 +867,7 @@
     "typescript": {
       "version": "3.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.5.tgz",
-      "integrity": "sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==",
-      "dev": true
+      "integrity": "sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ=="
     },
     "vscode-css-languageservice": {
       "version": "4.2.0",

--- a/language-server/package.json
+++ b/language-server/package.json
@@ -9,6 +9,7 @@
   },
   "main": "./out/htmlServerMain",
   "dependencies": {
+    "typescript": "^3.9.5",
     "vscode-css-languageservice": "^4.1.2",
     "vscode-html-languageservice": "^3.1.0-next.2",
     "vscode-languageserver": "^6.1.1",
@@ -21,8 +22,7 @@
     "glob": "^7.1.6",
     "mocha": "^7.1.2",
     "mocha-junit-reporter": "^1.23.3",
-    "mocha-multi-reporters": "^1.1.7",
-    "typescript": "^3.9.5"
+    "mocha-multi-reporters": "^1.1.7"
   },
   "scripts": {
     "compile": "npx gulp compile-extension:html-language-features-server",


### PR DESCRIPTION
https://github.com/sublimelsp/LSP-html/pull/10#issuecomment-644912603

For `LSP-html`, `typescript` should be in `dependencies` rather than `devDependencies`. 

The build script will [add it automatically](https://github.com/sublimelsp/LSP-html/blob/fa91b349f6362b16ffb7b2ab85f810ec5f3230fe/language-server/compile-language-server.sh#L55) but it was copied from `LSP-css` whose `typescript` should be [in `devDependencies`](https://github.com/sublimelsp/LSP-css/blob/70b36611a7509fbfdd4e0c0ff0ccbfe2843605c3/language-server/compile-language-server.sh#L56) and I guess I ran the build script before I fix the `typescript` dependency problem (for `LSP-html`, `-D` should be removed) and I forgot to re-run it.

Given the fact that `LSP-html` is not currently workable, we need another release.
