### PR TITLE
Use ${node_bin} for the node binary

### DIFF
--- a/LSP-html.sublime-settings
+++ b/LSP-html.sublime-settings
@@ -1,4 +1,5 @@
 {
+	"command": ["${node_bin}", "${server_path}", "--stdio"],
 	"languages": [
 		{
 			"languageId": "html",

--- a/plugin.py
+++ b/plugin.py
@@ -1,6 +1,5 @@
 from lsp_utils import NpmClientHandler
 import os
-import sublime
 
 
 def plugin_loaded():
@@ -15,15 +14,3 @@ class LspHtmlPlugin(NpmClientHandler):
     package_name = __package__
     server_directory = 'language-server'
     server_binary_path = os.path.join(server_directory, 'out', 'node', 'htmlServerMain.js')
-
-    def on_pre_server_command(self, command, done_callback):
-        cmd = command["command"]
-        if cmd == "editor.action.triggerSuggest":
-            session = self.weaksession()
-            if session:
-                view = session.window.active_view()
-                if view:
-                    sublime.set_timeout(lambda: view.run_command("auto_complete"))
-                    done_callback()
-                    return True
-        return False


### PR DESCRIPTION
With the latest version of lsp_utils a change was introduced [1] that allows using a locally
managed node runtime instead of the system one. For that to work, the "node" command
needs to use a variable.

[1] https://github.com/sublimelsp/lsp_utils/commit/403345a0c5c15e84802c712044c630a9fb236b9d