### PR TITLE
chore: update server

### DIFF
--- a/language-server/compile-language-server.sh
+++ b/language-server/compile-language-server.sh
@@ -54,11 +54,11 @@ popd || exit
 
 pushd "${SRC_DIR}" || exit
 
-npm install
+npm install --lockfile-version 2
 
 # @see https://github.com/microsoft/vscode/blob/main/extensions/package.json
-npm install typescript@^5.0.2
-npm install --include=dev @types/node
+npm install --lockfile-version 2 typescript@^5.2.0-dev.20230807
+npm install --lockfile-version 2 --include=dev @types/node
 
 popd || exit
 

--- a/language-server/html-language-features/server/out/htmlServer.js
+++ b/language-server/html-language-features/server/out/htmlServer.js
@@ -69,8 +69,9 @@ function startServer(connection, runtime) {
             let promise = documentSettings[textDocument.uri];
             if (!promise) {
                 const scopeUri = textDocument.uri;
-                const configRequestParam = { items: [{ scopeUri, section: 'css' }, { scopeUri, section: 'html' }, { scopeUri, section: 'javascript' }] };
-                promise = connection.sendRequest(vscode_languageserver_1.ConfigurationRequest.type, configRequestParam).then(s => ({ css: s[0], html: s[1], javascript: s[2] }));
+                const sections = ['css', 'html', 'javascript', 'js/ts'];
+                const configRequestParam = { items: sections.map(section => ({ scopeUri, section })) };
+                promise = connection.sendRequest(vscode_languageserver_1.ConfigurationRequest.type, configRequestParam).then(s => ({ css: s[0], html: s[1], javascript: s[2], 'js/ts': s[3] }));
                 documentSettings[textDocument.uri] = promise;
             }
             return promise;

--- a/language-server/html-language-features/server/out/modes/formatting.js
+++ b/language-server/html-language-features/server/out/modes/formatting.js
@@ -49,7 +49,11 @@ async function format(languageModes, document, formatRange, formattingOptions, s
     // perform a html format and apply changes to a new document
     const htmlMode = languageModes.getMode('html');
     const htmlEdits = await htmlMode.format(document, formatRange, formattingOptions, settings);
-    const htmlFormattedContent = languageModes_1.TextDocument.applyEdits(document, htmlEdits);
+    let htmlFormattedContent = languageModes_1.TextDocument.applyEdits(document, htmlEdits);
+    if (formattingOptions.insertFinalNewline && endOffset === content.length && !htmlFormattedContent.endsWith('\n')) {
+        htmlFormattedContent = htmlFormattedContent + '\n';
+        htmlEdits.push(languageModes_1.TextEdit.insert(endPos, '\n'));
+    }
     const newDocument = languageModes_1.TextDocument.create(document.uri + '.tmp', document.languageId, document.version, htmlFormattedContent);
     try {
         // run embedded formatters on html formatted content: - formatters see correct initial indent

--- a/language-server/html-language-features/server/out/modes/htmlMode.js
+++ b/language-server/html-language-features/server/out/modes/htmlMode.js
@@ -44,9 +44,6 @@ function getHTMLMode(htmlLanguageService, workspace) {
             else {
                 formatSettings.contentUnformatted = 'script';
             }
-            if (formatParams.insertFinalNewline) {
-                formatSettings.endWithNewline = true;
-            }
             merge(formatParams, formatSettings);
             return htmlLanguageService.format(document, range, formatSettings);
         },

--- a/language-server/html-language-features/server/out/modes/javascriptMode.js
+++ b/language-server/html-language-features/server/out/modes/javascriptMode.js
@@ -94,12 +94,17 @@ function getJavaScriptMode(documentRegions, languageId, workspace) {
     const jsDocuments = (0, languageModelCache_1.getLanguageModelCache)(10, 60, document => documentRegions.get(document).getEmbeddedDocument(languageId));
     const host = getLanguageServiceHost(languageId === 'javascript' ? ts.ScriptKind.JS : ts.ScriptKind.TS);
     const globalSettings = {};
+    function updateHostSettings(settings) {
+        const hostSettings = host.getCompilationSettings();
+        hostSettings.experimentalDecorators = settings?.['js/ts']?.implicitProjectConfig?.experimentalDecorators;
+        hostSettings.strictNullChecks = settings?.['js/ts']?.implicitProjectConfig.strictNullChecks;
+    }
     return {
         getId() {
             return languageId;
         },
         async doValidation(document, settings = workspace.settings) {
-            host.getCompilationSettings()['experimentalDecorators'] = settings && settings.javascript && settings.javascript.implicitProjectConfig.experimentalDecorators;
+            updateHostSettings(settings);
             const jsDocument = jsDocuments.get(document);
             const languageService = await host.getLanguageService(jsDocument);
             const syntaxDiagnostics = languageService.getSyntacticDiagnostics(jsDocument.uri);

--- a/language-server/html-language-features/server/out/requests.js
+++ b/language-server/html-language-features/server/out/requests.js
@@ -9,11 +9,11 @@ const vscode_languageserver_1 = require("vscode-languageserver");
 var FsStatRequest;
 (function (FsStatRequest) {
     FsStatRequest.type = new vscode_languageserver_1.RequestType('fs/stat');
-})(FsStatRequest = exports.FsStatRequest || (exports.FsStatRequest = {}));
+})(FsStatRequest || (exports.FsStatRequest = FsStatRequest = {}));
 var FsReadDirRequest;
 (function (FsReadDirRequest) {
     FsReadDirRequest.type = new vscode_languageserver_1.RequestType('fs/readDir');
-})(FsReadDirRequest = exports.FsReadDirRequest || (exports.FsReadDirRequest = {}));
+})(FsReadDirRequest || (exports.FsReadDirRequest = FsReadDirRequest = {}));
 var FileType;
 (function (FileType) {
     /**
@@ -32,7 +32,7 @@ var FileType;
      * A symbolic link to a file.
      */
     FileType[FileType["SymbolicLink"] = 64] = "SymbolicLink";
-})(FileType = exports.FileType || (exports.FileType = {}));
+})(FileType || (exports.FileType = FileType = {}));
 function getFileSystemProvider(handledSchemas, connection, runtime) {
     const fileFs = runtime.fileFs && handledSchemas.indexOf('file') !== -1 ? runtime.fileFs : undefined;
     return {

--- a/language-server/package-lock.json
+++ b/language-server/package-lock.json
@@ -9,17 +9,17 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@vscode/l10n": "^0.0.11",
-        "typescript": "^5.0.2",
-        "vscode-css-languageservice": "^6.2.4",
-        "vscode-html-languageservice": "^5.0.4",
-        "vscode-languageserver": "^8.1.0",
+        "@vscode/l10n": "^0.0.14",
+        "typescript": "^5.2.0-dev.20230807",
+        "vscode-css-languageservice": "^6.2.6",
+        "vscode-html-languageservice": "^5.0.6",
+        "vscode-languageserver": "^8.2.0-next.1",
         "vscode-languageserver-textdocument": "^1.0.8",
         "vscode-uri": "^3.0.7"
       },
       "devDependencies": {
         "@types/mocha": "^9.1.1",
-        "@types/node": "^16.18.18"
+        "@types/node": "^18.17.6"
       },
       "engines": {
         "node": "*"
@@ -32,77 +32,82 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.18.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.18.tgz",
-      "integrity": "sha512-fwGw1uvQAzabxL1pyoknPlJIF2t7+K90uTqynleKRx24n3lYcxWa3+KByLhgkF8GEAK2c7hC8Ki0RkNM5H15jQ==",
+      "version": "18.17.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.6.tgz",
+      "integrity": "sha512-fGmT/P7z7ecA6bv/ia5DlaWCH4YeZvAQMNpUhrJjtAhOhZfoxS1VLUgU2pdk63efSjQaOJWdXMuAJsws+8I6dg==",
       "dev": true
     },
     "node_modules/@vscode/l10n": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.11.tgz",
-      "integrity": "sha512-ukOMWnCg1tCvT7WnDfsUKQOFDQGsyR5tNgRpwmqi+5/vzU3ghdDXzvIM4IOPdSb3OeSsBNvmSL8nxIVOqi2WXA=="
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.14.tgz",
+      "integrity": "sha512-/yrv59IEnmh655z1oeDnGcvMYwnEzNzHLgeYcQCkhYX0xBvYWrAuefoiLcPBUkMpJsb46bqQ6Yv4pwTTQ4d3Qg=="
     },
     "node_modules/typescript": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
-      "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
+      "version": "5.2.0-dev.20230807",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.0-dev.20230807.tgz",
+      "integrity": "sha512-sF8sZl3r/mpAdKAxASaWaoU+mNPF3g8OrZ601HraU2l4WEwAf6nO7sq0Bzl+Y3FV7sWjy+gb6kdM1CtLjVne/g==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=12.20"
+        "node": ">=14.17"
       }
     },
     "node_modules/vscode-css-languageservice": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.2.4.tgz",
-      "integrity": "sha512-9UG0s3Ss8rbaaPZL1AkGzdjrGY8F+P+Ne9snsrvD9gxltDGhsn8C2dQpqQewHrMW37OvlqJoI8sUU2AWDb+qNw==",
+      "version": "6.2.6",
+      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.2.6.tgz",
+      "integrity": "sha512-SA2WkeOecIpUiEbZnjOsP/fI5CRITZEiQGSHXKiDQDwLApfKcnLhZwMtOBbIifSzESVcQa7b/shX/nbnF4NoCg==",
       "dependencies": {
-        "@vscode/l10n": "^0.0.11",
+        "@vscode/l10n": "^0.0.14",
         "vscode-languageserver-textdocument": "^1.0.8",
         "vscode-languageserver-types": "^3.17.3",
         "vscode-uri": "^3.0.7"
       }
     },
     "node_modules/vscode-html-languageservice": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.0.4.tgz",
-      "integrity": "sha512-tvrySfpglu4B2rQgWGVO/IL+skvU7kBkQotRlxA7ocSyRXOZUd6GA13XHkxo8LPe07KWjeoBlN1aVGqdfTK4xA==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.0.6.tgz",
+      "integrity": "sha512-gCixNg6fjPO7+kwSMBAVXcwDRHdjz1WOyNfI0n5Wx0J7dfHG8ggb3zD1FI8E2daTZrwS1cooOiSoc1Xxph4qRQ==",
       "dependencies": {
-        "@vscode/l10n": "^0.0.11",
+        "@vscode/l10n": "^0.0.14",
         "vscode-languageserver-textdocument": "^1.0.8",
-        "vscode-languageserver-types": "^3.17.2",
+        "vscode-languageserver-types": "^3.17.3",
         "vscode-uri": "^3.0.7"
       }
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0.tgz",
-      "integrity": "sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw==",
+      "version": "8.2.0-next.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0-next.0.tgz",
+      "integrity": "sha512-13jYzaFQpTz5qQ2P+l5c/iTVsj1wUpflP0CR/v4XaEpM0oToLEXZBTcuuox1WaGIbu3Av3xxmGNU4Hydl1iNKg==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/vscode-languageserver": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.1.0.tgz",
-      "integrity": "sha512-eUt8f1z2N2IEUDBsKaNapkz7jl5QpskN2Y0G01T/ItMxBxw1fJwvtySGB9QMecatne8jFIWJGWI61dWjyTLQsw==",
+      "version": "8.2.0-next.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.2.0-next.1.tgz",
+      "integrity": "sha512-994AXMKBijzjlnpf8p9M+ntsNJDjR8pr55NJPYxKjy/nUhVkg962dAomelH6Z94401kBZmSbfP/K/20cB54aFA==",
       "dependencies": {
-        "vscode-languageserver-protocol": "3.17.3"
+        "vscode-languageserver-protocol": "3.17.4-next.1"
       },
       "bin": {
         "installServerIntoExtension": "bin/installServerIntoExtension"
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3.tgz",
-      "integrity": "sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==",
+      "version": "3.17.4-next.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.4-next.1.tgz",
+      "integrity": "sha512-qrK4BycgPR/+nkRN9PRVTblkLp+kUPUmAgF6rDhFzZIPXW4/MqWwFUT8uswIMGdlTPPgCEkFO/AYEZK1fDXODg==",
       "dependencies": {
-        "vscode-jsonrpc": "8.1.0",
-        "vscode-languageserver-types": "3.17.3"
+        "vscode-jsonrpc": "8.2.0-next.0",
+        "vscode-languageserver-types": "3.17.4-next.0"
       }
+    },
+    "node_modules/vscode-languageserver-protocol/node_modules/vscode-languageserver-types": {
+      "version": "3.17.4-next.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.4-next.0.tgz",
+      "integrity": "sha512-2FPKboHnT04xYjfM8JpJVBz4a/tryMw58jmzucaabZMZN5hzoFBrhc97jNG4n6edr9JUb9+QSwwcAcYpDTAoag=="
     },
     "node_modules/vscode-languageserver-textdocument": {
       "version": "1.0.8",
@@ -128,63 +133,70 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.18.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.18.tgz",
-      "integrity": "sha512-fwGw1uvQAzabxL1pyoknPlJIF2t7+K90uTqynleKRx24n3lYcxWa3+KByLhgkF8GEAK2c7hC8Ki0RkNM5H15jQ==",
+      "version": "18.17.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.6.tgz",
+      "integrity": "sha512-fGmT/P7z7ecA6bv/ia5DlaWCH4YeZvAQMNpUhrJjtAhOhZfoxS1VLUgU2pdk63efSjQaOJWdXMuAJsws+8I6dg==",
       "dev": true
     },
     "@vscode/l10n": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.11.tgz",
-      "integrity": "sha512-ukOMWnCg1tCvT7WnDfsUKQOFDQGsyR5tNgRpwmqi+5/vzU3ghdDXzvIM4IOPdSb3OeSsBNvmSL8nxIVOqi2WXA=="
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.14.tgz",
+      "integrity": "sha512-/yrv59IEnmh655z1oeDnGcvMYwnEzNzHLgeYcQCkhYX0xBvYWrAuefoiLcPBUkMpJsb46bqQ6Yv4pwTTQ4d3Qg=="
     },
     "typescript": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
-      "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw=="
+      "version": "5.2.0-dev.20230807",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.0-dev.20230807.tgz",
+      "integrity": "sha512-sF8sZl3r/mpAdKAxASaWaoU+mNPF3g8OrZ601HraU2l4WEwAf6nO7sq0Bzl+Y3FV7sWjy+gb6kdM1CtLjVne/g=="
     },
     "vscode-css-languageservice": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.2.4.tgz",
-      "integrity": "sha512-9UG0s3Ss8rbaaPZL1AkGzdjrGY8F+P+Ne9snsrvD9gxltDGhsn8C2dQpqQewHrMW37OvlqJoI8sUU2AWDb+qNw==",
+      "version": "6.2.6",
+      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.2.6.tgz",
+      "integrity": "sha512-SA2WkeOecIpUiEbZnjOsP/fI5CRITZEiQGSHXKiDQDwLApfKcnLhZwMtOBbIifSzESVcQa7b/shX/nbnF4NoCg==",
       "requires": {
-        "@vscode/l10n": "^0.0.11",
+        "@vscode/l10n": "^0.0.14",
         "vscode-languageserver-textdocument": "^1.0.8",
         "vscode-languageserver-types": "^3.17.3",
         "vscode-uri": "^3.0.7"
       }
     },
     "vscode-html-languageservice": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.0.4.tgz",
-      "integrity": "sha512-tvrySfpglu4B2rQgWGVO/IL+skvU7kBkQotRlxA7ocSyRXOZUd6GA13XHkxo8LPe07KWjeoBlN1aVGqdfTK4xA==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.0.6.tgz",
+      "integrity": "sha512-gCixNg6fjPO7+kwSMBAVXcwDRHdjz1WOyNfI0n5Wx0J7dfHG8ggb3zD1FI8E2daTZrwS1cooOiSoc1Xxph4qRQ==",
       "requires": {
-        "@vscode/l10n": "^0.0.11",
+        "@vscode/l10n": "^0.0.14",
         "vscode-languageserver-textdocument": "^1.0.8",
-        "vscode-languageserver-types": "^3.17.2",
+        "vscode-languageserver-types": "^3.17.3",
         "vscode-uri": "^3.0.7"
       }
     },
     "vscode-jsonrpc": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0.tgz",
-      "integrity": "sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw=="
+      "version": "8.2.0-next.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0-next.0.tgz",
+      "integrity": "sha512-13jYzaFQpTz5qQ2P+l5c/iTVsj1wUpflP0CR/v4XaEpM0oToLEXZBTcuuox1WaGIbu3Av3xxmGNU4Hydl1iNKg=="
     },
     "vscode-languageserver": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.1.0.tgz",
-      "integrity": "sha512-eUt8f1z2N2IEUDBsKaNapkz7jl5QpskN2Y0G01T/ItMxBxw1fJwvtySGB9QMecatne8jFIWJGWI61dWjyTLQsw==",
+      "version": "8.2.0-next.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.2.0-next.1.tgz",
+      "integrity": "sha512-994AXMKBijzjlnpf8p9M+ntsNJDjR8pr55NJPYxKjy/nUhVkg962dAomelH6Z94401kBZmSbfP/K/20cB54aFA==",
       "requires": {
-        "vscode-languageserver-protocol": "3.17.3"
+        "vscode-languageserver-protocol": "3.17.4-next.1"
       }
     },
     "vscode-languageserver-protocol": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3.tgz",
-      "integrity": "sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==",
+      "version": "3.17.4-next.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.4-next.1.tgz",
+      "integrity": "sha512-qrK4BycgPR/+nkRN9PRVTblkLp+kUPUmAgF6rDhFzZIPXW4/MqWwFUT8uswIMGdlTPPgCEkFO/AYEZK1fDXODg==",
       "requires": {
-        "vscode-jsonrpc": "8.1.0",
-        "vscode-languageserver-types": "3.17.3"
+        "vscode-jsonrpc": "8.2.0-next.0",
+        "vscode-languageserver-types": "3.17.4-next.0"
+      },
+      "dependencies": {
+        "vscode-languageserver-types": {
+          "version": "3.17.4-next.0",
+          "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.4-next.0.tgz",
+          "integrity": "sha512-2FPKboHnT04xYjfM8JpJVBz4a/tryMw58jmzucaabZMZN5hzoFBrhc97jNG4n6edr9JUb9+QSwwcAcYpDTAoag=="
+        }
       }
     },
     "vscode-languageserver-textdocument": {

--- a/language-server/package.json
+++ b/language-server/package.json
@@ -9,17 +9,17 @@
   },
   "main": "./out/node/htmlServerMain",
   "dependencies": {
-    "@vscode/l10n": "^0.0.11",
-    "typescript": "^5.0.2",
-    "vscode-css-languageservice": "^6.2.4",
-    "vscode-html-languageservice": "^5.0.4",
-    "vscode-languageserver": "^8.1.0",
+    "@vscode/l10n": "^0.0.14",
+    "typescript": "^5.2.0-dev.20230807",
+    "vscode-css-languageservice": "^6.2.6",
+    "vscode-html-languageservice": "^5.0.6",
+    "vscode-languageserver": "^8.2.0-next.1",
     "vscode-languageserver-textdocument": "^1.0.8",
     "vscode-uri": "^3.0.7"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",
-    "@types/node": "^16.18.18"
+    "@types/node": "^18.17.6"
   },
   "scripts": {
     "compile": "npx gulp compile-extension:html-language-features-server",

--- a/language-server/update-info.log
+++ b/language-server/update-info.log
@@ -1,2 +1,2 @@
 Archive:  src-main.zip
-13e6f5f007215ffe9efc814ce42f720f1ff24041
+df7e41cc5ae63ac4f74258ba098deb070acf5ac1


### PR DESCRIPTION
As a note, `npm install` generates the lockfile in v3 format with my npm v9.6.7. `yarn` failed to convert v3 npm lockfile into a yarn lockfile. So I added `--lockfile-version 2` flag to force v2 npm lockfile generation.